### PR TITLE
Update categories api

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -107,7 +107,7 @@ function clearSheet() {
 }
 
 function getCategories() {
-  var catUrl = 'https://api.sketchfab.com/v2/categories',
+  var catUrl = 'https://api.sketchfab.com/v3/categories',
     catResponse = UrlFetchApp.fetch( catUrl );
   
   return JSON.parse( catResponse.getContentText() ).results;


### PR DESCRIPTION
This needed to be updated due to the deprecation of the categories API for V2. As this request failed, the sheet failed to populate and allow user to specify values for each upload. If I ever have time I may attempt a full update to the V3 API and implement OAuth if possible, but this will get the script working for the moment. 